### PR TITLE
Add unit-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
     token:
       secure: "WqmQamwsARE9sVvMZOnWhTjDb3FcMtPXvbhH6kCxDZn8iExfhj87VlGyGC6d23DvMop/dfpICjd4VyQu+HmLBXzdkFa0CzseS4mShTwwgTzBh0otD/51AICm8qMdjQ+7oe9tZJkxTwUGVzzOm9MG5oPx34vuwvE3Jwa54VI1XmBY5/bgngh6Xg1bEMbVOP/A/dj+fmJUn8AVJPIMYwIeq7wgt2hfC/hFXLJ3Qhnpr5xCz3gl5xmVMc5rhrFh7cN/SeoVrXY2JXtz1Ud1S9YRcMyck1wWwILykaa+o/UpMFK1Mz+Q+Dp8la6WfyNvTIN2xDSGMwVmXYQSVCb5VyliEIvSUKk1hE2YK6VYPOtV60IRX7pva4YUv4DX5kfgXTK9s1gSP4eukWwvpQtMdML3jVnd6/cI85WrrTuynatjRdVTIYCCh+qV4OgoeSNOyCdHYRaQv8FUWGXMozGYXyLZ69oVASWnB6A91gR44whVsDl+om+Ot8b+g0SOfBDqUFCWIF1JLxCo7yUEUo8/kpa+S03qQyyzWnOW2D1AF7rD3fRG7lGJWJhuELSYdKSGrTOCawdHiKHHLjS6gY0dV4s6z+NdpWLgiD/lrDw4/PsOwDy6OBQ2EMbJvsLP5CzThBq2pbVU7IHKWaF2keZPpYabQPP2brQ68rumgQTWoIkojn8="
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 script:
   - mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B
 notifications:

--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.2.0</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
@@ -107,17 +100,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${version.slf4j}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${version.slf4j}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_check_api</artifactId>
       <version>${version.errorprone}</version>
@@ -128,29 +110,11 @@
       <artifactId>error_prone_test_helpers</artifactId>
       <version>${version.errorprone}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>5.2.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.2.0</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.19.0</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${version.slf4j}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_test_helpers</artifactId>
+      <version>${version.errorprone}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.2.0</version>
@@ -140,18 +152,6 @@
       <artifactId>mockito-core</artifactId>
       <version>2.19.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.truth</groupId>
-      <artifactId>truth</artifactId>
-      <version>0.41</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <profiles>

--- a/src/test/java/jp/skypencil/errorprone/slf4j/DoNotPublishSlf4jLoggerTest.java
+++ b/src/test/java/jp/skypencil/errorprone/slf4j/DoNotPublishSlf4jLoggerTest.java
@@ -1,0 +1,90 @@
+package jp.skypencil.errorprone.slf4j;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
+import com.google.errorprone.bugpatterns.BugChecker;
+
+class DoNotPublishSlf4jLoggerTest {
+    @Test
+    @DisplayName("Refactoring feature should remove 'public' modifier")
+    void testRefactoringPublicLogger() throws IOException {
+        BugChecker checker = new DoNotPublishSlf4jLogger();
+        BugCheckerRefactoringTestHelper helper = BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
+        helper
+            .addInputLines("PublicLogger.java",
+                    "import org.slf4j.Logger;\n" + 
+                    "import org.slf4j.LoggerFactory;\n" + 
+                    "\n" + 
+                    "public class PublicLogger {\n" + 
+                    "    public static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
+                    "    public Logger logger = LoggerFactory.getLogger(getClass());\n" + 
+                    "}")
+            .addOutputLines("PublicLogger.java",
+                    "import org.slf4j.Logger;\n" + 
+                    "import org.slf4j.LoggerFactory;\n" + 
+                    "\n" + 
+                    "public class PublicLogger {\n" + 
+                    "    private static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
+                    "    private Logger logger = LoggerFactory.getLogger(getClass());\n" + 
+                    "}\n" + 
+                    "")
+            .doTest(TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    @DisplayName("Refactoring feature should remove 'protected' modifier")
+    void testRefactoringProtectedLogger() throws IOException {
+        BugChecker checker = new DoNotPublishSlf4jLogger();
+        BugCheckerRefactoringTestHelper helper = BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
+        helper
+        .addInputLines("ProtectedLogger.java",
+                "import org.slf4j.Logger;\n" + 
+                "import org.slf4j.LoggerFactory;\n" + 
+                "\n" + 
+                "public class ProtectedLogger {\n" + 
+                "    protected static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
+                "    protected Logger logger = LoggerFactory.getLogger(getClass());\n" + 
+                "}")
+        .addOutputLines("ProtectedLogger.java",
+                "import org.slf4j.Logger;\n" + 
+                "import org.slf4j.LoggerFactory;\n" + 
+                "\n" + 
+                "public class ProtectedLogger {\n" + 
+                "    private static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
+                "    private Logger logger = LoggerFactory.getLogger(getClass());\n" + 
+                "}\n" + 
+                "")
+        .doTest(TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    @DisplayName("Refactoring feature should add 'private' modifier to package-private fields")
+    void testRefactoringPackagePrivateLogger() throws IOException {
+        BugChecker checker = new DoNotPublishSlf4jLogger();
+        BugCheckerRefactoringTestHelper helper = BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
+        helper
+        .addInputLines("PackagePrivateLogger.java",
+                "import org.slf4j.Logger;\n" + 
+                "import org.slf4j.LoggerFactory;\n" + 
+                "\n" + 
+                "public class PackagePrivateLogger {\n" + 
+                "    static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
+                "    Logger logger = LoggerFactory.getLogger(getClass());\n" + 
+                "}")
+        .addOutputLines("PackagePrivateLogger.java",
+                "import org.slf4j.Logger;\n" + 
+                "import org.slf4j.LoggerFactory;\n" + 
+                "\n" + 
+                "public class PackagePrivateLogger {\n" + 
+                "    private static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
+                "    private Logger logger = LoggerFactory.getLogger(getClass());\n" + 
+                "}\n" + 
+                "")
+        .doTest(TestMode.TEXT_MATCH);
+    }
+}

--- a/src/test/java/jp/skypencil/errorprone/slf4j/DoNotPublishSlf4jLoggerTest.java
+++ b/src/test/java/jp/skypencil/errorprone/slf4j/DoNotPublishSlf4jLoggerTest.java
@@ -1,90 +1,93 @@
 package jp.skypencil.errorprone.slf4j;
 
-import java.io.IOException;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.bugpatterns.BugChecker;
+import java.io.IOException;
+import org.junit.Test;
 
-class DoNotPublishSlf4jLoggerTest {
-    @Test
-    @DisplayName("Refactoring feature should remove 'public' modifier")
-    void testRefactoringPublicLogger() throws IOException {
-        BugChecker checker = new DoNotPublishSlf4jLogger();
-        BugCheckerRefactoringTestHelper helper = BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
-        helper
-            .addInputLines("PublicLogger.java",
-                    "import org.slf4j.Logger;\n" + 
-                    "import org.slf4j.LoggerFactory;\n" + 
-                    "\n" + 
-                    "public class PublicLogger {\n" + 
-                    "    public static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
-                    "    public Logger logger = LoggerFactory.getLogger(getClass());\n" + 
-                    "}")
-            .addOutputLines("PublicLogger.java",
-                    "import org.slf4j.Logger;\n" + 
-                    "import org.slf4j.LoggerFactory;\n" + 
-                    "\n" + 
-                    "public class PublicLogger {\n" + 
-                    "    private static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
-                    "    private Logger logger = LoggerFactory.getLogger(getClass());\n" + 
-                    "}\n" + 
-                    "")
-            .doTest(TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    @DisplayName("Refactoring feature should remove 'protected' modifier")
-    void testRefactoringProtectedLogger() throws IOException {
-        BugChecker checker = new DoNotPublishSlf4jLogger();
-        BugCheckerRefactoringTestHelper helper = BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
-        helper
-        .addInputLines("ProtectedLogger.java",
-                "import org.slf4j.Logger;\n" + 
-                "import org.slf4j.LoggerFactory;\n" + 
-                "\n" + 
-                "public class ProtectedLogger {\n" + 
-                "    protected static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
-                "    protected Logger logger = LoggerFactory.getLogger(getClass());\n" + 
-                "}")
-        .addOutputLines("ProtectedLogger.java",
-                "import org.slf4j.Logger;\n" + 
-                "import org.slf4j.LoggerFactory;\n" + 
-                "\n" + 
-                "public class ProtectedLogger {\n" + 
-                "    private static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
-                "    private Logger logger = LoggerFactory.getLogger(getClass());\n" + 
-                "}\n" + 
-                "")
+public class DoNotPublishSlf4jLoggerTest {
+  @Test
+  public void testRefactoringPublicLogger() throws IOException {
+    BugChecker checker = new DoNotPublishSlf4jLogger();
+    BugCheckerRefactoringTestHelper helper =
+        BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
+    helper
+        .addInputLines(
+            "PublicLogger.java",
+            "import org.slf4j.Logger;\n"
+                + "import org.slf4j.LoggerFactory;\n"
+                + "\n"
+                + "public class PublicLogger {\n"
+                + "    public static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n"
+                + "    public Logger logger = LoggerFactory.getLogger(getClass());\n"
+                + "}")
+        .addOutputLines(
+            "PublicLogger.java",
+            "import org.slf4j.Logger;\n"
+                + "import org.slf4j.LoggerFactory;\n"
+                + "\n"
+                + "public class PublicLogger {\n"
+                + "    private static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n"
+                + "    private Logger logger = LoggerFactory.getLogger(getClass());\n"
+                + "}\n"
+                + "")
         .doTest(TestMode.TEXT_MATCH);
-    }
+  }
 
-    @Test
-    @DisplayName("Refactoring feature should add 'private' modifier to package-private fields")
-    void testRefactoringPackagePrivateLogger() throws IOException {
-        BugChecker checker = new DoNotPublishSlf4jLogger();
-        BugCheckerRefactoringTestHelper helper = BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
-        helper
-        .addInputLines("PackagePrivateLogger.java",
-                "import org.slf4j.Logger;\n" + 
-                "import org.slf4j.LoggerFactory;\n" + 
-                "\n" + 
-                "public class PackagePrivateLogger {\n" + 
-                "    static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
-                "    Logger logger = LoggerFactory.getLogger(getClass());\n" + 
-                "}")
-        .addOutputLines("PackagePrivateLogger.java",
-                "import org.slf4j.Logger;\n" + 
-                "import org.slf4j.LoggerFactory;\n" + 
-                "\n" + 
-                "public class PackagePrivateLogger {\n" + 
-                "    private static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n" + 
-                "    private Logger logger = LoggerFactory.getLogger(getClass());\n" + 
-                "}\n" + 
-                "")
+  @Test
+  public void testRefactoringProtectedLogger() throws IOException {
+    BugChecker checker = new DoNotPublishSlf4jLogger();
+    BugCheckerRefactoringTestHelper helper =
+        BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
+    helper
+        .addInputLines(
+            "ProtectedLogger.java",
+            "import org.slf4j.Logger;\n"
+                + "import org.slf4j.LoggerFactory;\n"
+                + "\n"
+                + "public class ProtectedLogger {\n"
+                + "    protected static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n"
+                + "    protected Logger logger = LoggerFactory.getLogger(getClass());\n"
+                + "}")
+        .addOutputLines(
+            "ProtectedLogger.java",
+            "import org.slf4j.Logger;\n"
+                + "import org.slf4j.LoggerFactory;\n"
+                + "\n"
+                + "public class ProtectedLogger {\n"
+                + "    private static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n"
+                + "    private Logger logger = LoggerFactory.getLogger(getClass());\n"
+                + "}\n"
+                + "")
         .doTest(TestMode.TEXT_MATCH);
-    }
+  }
+
+  @Test
+  public void testRefactoringPackagePrivateLogger() throws IOException {
+    BugChecker checker = new DoNotPublishSlf4jLogger();
+    BugCheckerRefactoringTestHelper helper =
+        BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
+    helper
+        .addInputLines(
+            "PackagePrivateLogger.java",
+            "import org.slf4j.Logger;\n"
+                + "import org.slf4j.LoggerFactory;\n"
+                + "\n"
+                + "public class PackagePrivateLogger {\n"
+                + "    static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n"
+                + "    Logger logger = LoggerFactory.getLogger(getClass());\n"
+                + "}")
+        .addOutputLines(
+            "PackagePrivateLogger.java",
+            "import org.slf4j.Logger;\n"
+                + "import org.slf4j.LoggerFactory;\n"
+                + "\n"
+                + "public class PackagePrivateLogger {\n"
+                + "    private static Logger LOGGER = LoggerFactory.getLogger(\"static\");\n"
+                + "    private Logger logger = LoggerFactory.getLogger(getClass());\n"
+                + "}\n"
+                + "")
+        .doTest(TestMode.TEXT_MATCH);
+  }
 }


### PR DESCRIPTION
Refer [official document](https://github.com/google/error-prone/wiki/Writing-a-check) for detail.
This build fails with JDK9 following error, so temporally using JDK9 in Travis CI.

```
[ERROR] testRefactoringPackagePrivateLogger(jp.skypencil.errorprone.slf4j.DoNotPublishSlf4jLoggerTest)  Time elapsed: 0.105 s  <<< ERROR!
java.lang.NoSuchFieldError: ANNOTATION_PROCESSOR_MODULE_PATH
	at jp.skypencil.errorprone.slf4j.DoNotPublishSlf4jLoggerTest.testRefactoringPackagePrivateLogger(DoNotPublishSlf4jLoggerTest.java:70)
```