### PR TITLE
Update to Error Prone 2.11.0

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.source>9</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.slf4j>2.0.0-alpha6</version.slf4j>
-    <version.errorprone>2.10.0</version.errorprone>
+    <version.errorprone>2.11.0</version.errorprone>
   </properties>
   <scm>
     <connection>scm:git:git@github.com:KengoTODA/errorprone-slf4j.git</connection>
@@ -50,29 +50,38 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <compilerId>javac-with-errorprone</compilerId>
           <source>9</source>
           <target>9</target>
           <encoding>${project.build.sourceEncoding}</encoding>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <showWarnings>true</showWarnings>
           <compilerArgs>
-            <!-- workaround to avoid the bug in errorprone https://github.com/google/error-prone/issues/780#issuecomment-357952383 -->
-            <arg>-Xep:ParameterName:OFF</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>
+              -Xplugin:ErrorProne
+              <!-- workaround to avoid the bug in errorprone https://github.com/google/error-prone/issues/780#issuecomment-357952383 -->
+              -Xep:ParameterName:OFF
+            </arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
           </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${version.errorprone}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.9.0</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>${version.errorprone}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,9 @@
               -Xep:ParameterName:OFF
             </arg>
             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>

--- a/src/main/java/jp/skypencil/errorprone/slf4j/DoNotPublishSlf4jLogger.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/DoNotPublishSlf4jLogger.java
@@ -7,7 +7,6 @@ import static com.google.errorprone.matchers.Matchers.not;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
@@ -22,8 +21,7 @@ import javax.lang.model.element.Modifier;
     name = "Slf4jLoggerShouldBePrivate",
     summary = "Do not publish Logger field, it should be private",
     tags = {"SLF4J"},
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 @AutoService(BugChecker.class)
 public class DoNotPublishSlf4jLogger extends BugChecker implements VariableTreeMatcher {
   private static final long serialVersionUID = 3718668951312958622L;

--- a/src/main/java/jp/skypencil/errorprone/slf4j/DoNotUseStaticSlf4jLogger.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/DoNotUseStaticSlf4jLogger.java
@@ -8,7 +8,6 @@ import static com.google.errorprone.matchers.Matchers.isStatic;
 import com.google.auto.service.AutoService;
 import com.google.common.base.CaseFormat;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
@@ -25,8 +24,7 @@ import javax.lang.model.element.Modifier;
     name = "Slf4jLoggerShouldBeNonStatic",
     summary = "Do not use static Logger field, use non-static one instead",
     tags = {"SLF4J"},
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 @AutoService(BugChecker.class)
 public class DoNotUseStaticSlf4jLogger extends BugChecker implements VariableTreeMatcher {
   private static final long serialVersionUID = 2656759159827947106L;

--- a/src/main/java/jp/skypencil/errorprone/slf4j/FormatShouldBeConst.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/FormatShouldBeConst.java
@@ -46,7 +46,7 @@ public class FormatShouldBeConst extends BugChecker implements MethodInvocationT
     String message =
         String.format(
             "SLF4J logging format should be constant value, but it is \'%s\'",
-            tree.getArguments().get(formatIndex));
+            state.getSourceForNode(tree.getArguments().get(formatIndex)));
     return Description.builder(
             tree,
             "Slf4jFormatShouldBeConst",

--- a/src/main/java/jp/skypencil/errorprone/slf4j/IllegalPassedClass.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/IllegalPassedClass.java
@@ -4,7 +4,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -33,8 +32,7 @@ import javax.lang.model.element.Modifier;
     name = "Slf4jIllegalPassedClass",
     summary = "LoggerFactory.getLogger(Class) should get the class that defines variable",
     tags = {"SLF4J"},
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 @AutoService(BugChecker.class)
 public class IllegalPassedClass extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/src/main/java/jp/skypencil/errorprone/slf4j/PreferFinalSlf4jLogger.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/PreferFinalSlf4jLogger.java
@@ -7,7 +7,6 @@ import static com.google.errorprone.matchers.Matchers.not;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
@@ -21,8 +20,7 @@ import javax.lang.model.element.Modifier;
     name = "Slf4jLoggerShouldBeFinal",
     summary = "Logger field should be final",
     tags = {"SLF4J"},
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 @AutoService(BugChecker.class)
 public class PreferFinalSlf4jLogger extends BugChecker implements VariableTreeMatcher {
   private static final long serialVersionUID = -5127926153475887075L;


### PR DESCRIPTION
* Switch to the -Xplugin: maven integration
  (http://errorprone.info/docs/installation)
* Remove uses of deprecated `ProvidesFix` constants in `@BugPattern`
  annotations
* Fix a http://errorprone.info/bugpattern/TreeToString warning