### PR TITLE
Redeploy v0.1.6 with enabled in-memory PGP key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: |
-          ./gradlew spotlessCheck build ${SONAR_TOKEN:+sonarqube}
+          ./gradlew build ${SONAR_TOKEN:+sonarqube}
           npm ci
           npx semantic-release
         env:
@@ -36,6 +36,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_sonatypeUsername: eller86
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: |
-          ./gradlew build ${SONAR_TOKEN:+sonarqube}
+          ./gradlew build sign ${SONAR_TOKEN:+sonarqube}
           npm ci
           npx semantic-release
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,7 @@ publishing {
                 artifactId = "errorprone-slf4j"
                 name.set("Error Prone SLF4J")
                 description.set("Error Prone plugin for SLF4J")
+                url.set("https://github.com/KengoTODA/errorprone-slf4j")
                 inceptionYear.set("2018")
                 licenses {
                     license {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,10 @@ val createJavadocOptionFile by tasks.registering {
         }
     }
 }
+
+val signingKey: String? by project
+val signingPassword: String? by project
+
 tasks {
     withType<JavaCompile> {
         sourceCompatibility = "9"
@@ -67,6 +71,11 @@ tasks {
     withType<Javadoc> {
         dependsOn(createJavadocOptionFile)
         options.optionFiles(addExportsFile)
+    }
+    withType<Sign> {
+        onlyIf {
+            signingKey.isNullOrEmpty().not() && signingPassword.isNullOrEmpty().not()
+        }
     }
     withType<SonarQubeTask> {
         dependsOn(jacocoTestReport)
@@ -132,4 +141,9 @@ publishing {
             }
         }
     }
+}
+
+signing {
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications["mavenJava"])
 }


### PR DESCRIPTION
TODO: add GitHub Secrets to handle in-memory PGP keys properly.

close #151