### PR TITLE
Add BugPattern links

### DIFF
--- a/src/main/java/jp/skypencil/errorprone/slf4j/DoNotPublishSlf4jLogger.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/DoNotPublishSlf4jLogger.java
@@ -8,6 +8,7 @@ import static com.google.errorprone.matchers.Matchers.not;
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -21,6 +22,8 @@ import javax.lang.model.element.Modifier;
     name = "Slf4jLoggerShouldBePrivate",
     summary = "Do not publish Logger field, it should be private",
     tags = {"SLF4J"},
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_private",
+    linkType = LinkType.CUSTOM,
     severity = WARNING)
 @AutoService(BugChecker.class)
 public class DoNotPublishSlf4jLogger extends BugChecker implements VariableTreeMatcher {

--- a/src/main/java/jp/skypencil/errorprone/slf4j/DoNotUseStaticSlf4jLogger.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/DoNotUseStaticSlf4jLogger.java
@@ -9,6 +9,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.base.CaseFormat;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -24,6 +25,8 @@ import javax.lang.model.element.Modifier;
     name = "Slf4jLoggerShouldBeNonStatic",
     summary = "Do not use static Logger field, use non-static one instead",
     tags = {"SLF4J"},
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_non_static",
+    linkType = LinkType.CUSTOM,
     severity = SUGGESTION)
 @AutoService(BugChecker.class)
 public class DoNotUseStaticSlf4jLogger extends BugChecker implements VariableTreeMatcher {

--- a/src/main/java/jp/skypencil/errorprone/slf4j/FormatShouldBeConst.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/FormatShouldBeConst.java
@@ -5,6 +5,7 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
@@ -18,6 +19,8 @@ import com.sun.tools.javac.util.List;
     name = "Slf4jFormatShouldBeConst",
     summary = "Format of SLF4J logging should be constant value",
     tags = {"SLF4J"},
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_format_should_be_const",
+    linkType = LinkType.CUSTOM,
     severity = ERROR)
 @AutoService(BugChecker.class)
 public class FormatShouldBeConst extends BugChecker implements MethodInvocationTreeMatcher {

--- a/src/main/java/jp/skypencil/errorprone/slf4j/IllegalPassedClass.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/IllegalPassedClass.java
@@ -6,6 +6,7 @@ import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.ErrorProneVersion;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -33,6 +34,8 @@ import javax.lang.model.element.Modifier;
     name = "Slf4jIllegalPassedClass",
     summary = "LoggerFactory.getLogger(Class) should get the class that defines variable",
     tags = {"SLF4J"},
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_illegal_passed_class",
+    linkType = LinkType.CUSTOM,
     severity = WARNING)
 @AutoService(BugChecker.class)
 public class IllegalPassedClass extends BugChecker implements MethodInvocationTreeMatcher {

--- a/src/main/java/jp/skypencil/errorprone/slf4j/ManuallyProvidedMessage.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/ManuallyProvidedMessage.java
@@ -5,6 +5,7 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -21,6 +22,8 @@ import java.util.function.Predicate;
     summary =
         "Do not log message returned from Throwable#getMessage and Throwable#getLocalizedMessage",
     tags = {"SLF4J"},
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_manually_provided_message",
+    linkType = LinkType.CUSTOM,
     severity = ERROR)
 @AutoService(BugChecker.class)
 public class ManuallyProvidedMessage extends BugChecker implements MethodInvocationTreeMatcher {

--- a/src/main/java/jp/skypencil/errorprone/slf4j/PlaceholderMismatch.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/PlaceholderMismatch.java
@@ -6,6 +6,7 @@ import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -20,6 +21,8 @@ import java.util.regex.Pattern;
     name = "Slf4jPlaceholderMismatch",
     summary = "Count of placeholder does not match with count of parameter",
     tags = {"SLF4J"},
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_place_holder_mismatch",
+    linkType = LinkType.CUSTOM,
     severity = ERROR)
 @AutoService(BugChecker.class)
 public class PlaceholderMismatch extends BugChecker implements MethodInvocationTreeMatcher {

--- a/src/main/java/jp/skypencil/errorprone/slf4j/PreferFinalSlf4jLogger.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/PreferFinalSlf4jLogger.java
@@ -8,6 +8,7 @@ import static com.google.errorprone.matchers.Matchers.not;
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -20,6 +21,8 @@ import javax.lang.model.element.Modifier;
     name = "Slf4jLoggerShouldBeFinal",
     summary = "Logger field should be final",
     tags = {"SLF4J"},
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_final",
+    linkType = LinkType.CUSTOM,
     severity = WARNING)
 @AutoService(BugChecker.class)
 public class PreferFinalSlf4jLogger extends BugChecker implements VariableTreeMatcher {

--- a/src/main/java/jp/skypencil/errorprone/slf4j/SignOnlyFormat.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/SignOnlyFormat.java
@@ -5,6 +5,7 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
@@ -18,6 +19,8 @@ import com.sun.tools.javac.util.List;
     name = "Slf4jSignOnlyFormat",
     summary = "To make log readable, log format should contain not only sign but also texts",
     tags = {"SLF4J"},
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_sign_only_format",
+    linkType = LinkType.CUSTOM,
     severity = ERROR)
 @AutoService(BugChecker.class)
 public class SignOnlyFormat extends BugChecker implements MethodInvocationTreeMatcher {


### PR DESCRIPTION
The default linkType in the BugPattern annotation is AUTOGENERATED and this generates incorrect links such as
https://errorprone.info/bugpattern/Slf4jSignOnlyFormat