### PR TITLE
enforce more errorprone checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.errorprone
 import org.sonarqube.gradle.SonarQubeTask
 
@@ -67,6 +68,16 @@ tasks {
         targetCompatibility = "11"
         options.compilerArgs.addAll(exportsArgs)
         options.errorprone.disableWarningsInGeneratedCode.set(true)
+
+        // enforce general checks
+        options.errorprone.check("BadImport", CheckSeverity.ERROR)
+        options.errorprone.check("MixedMutabilityReturnType", CheckSeverity.ERROR)
+
+        // enforce errorprone-specific checks
+        options.errorprone.check("MemoizeConstantVisitorStateLookups", CheckSeverity.ERROR)
+        options.errorprone.check("ASTHelpersSuggestions", CheckSeverity.ERROR)
+        // our bugpattern classes use custom names
+        options.errorprone.check("BugPatternNaming", CheckSeverity.OFF)
     }
     withType<Javadoc> {
         dependsOn(createJavadocOptionFile)

--- a/src/main/java/jp/skypencil/errorprone/slf4j/DoNotUseStaticSlf4jLogger.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/DoNotUseStaticSlf4jLogger.java
@@ -14,7 +14,6 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFix.Builder;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.VariableTree;
@@ -35,7 +34,7 @@ public class DoNotUseStaticSlf4jLogger extends BugChecker implements VariableTre
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {
     if (allOf(isField(), SLF4J_LOGGER, isStatic()).matches(tree, state)) {
-      Builder builder = SuggestedFix.builder();
+      SuggestedFix.Builder builder = SuggestedFix.builder();
       SuggestedFixes.removeModifiers(tree, state, Modifier.STATIC).ifPresent(builder::merge);
       suggestRename(tree, state).ifPresent(builder::merge);
 


### PR DESCRIPTION
- `BadImport` (violations fixed)
- `MixedMutabilityReturnType` (violations fixed)
- `MemoizeConstantVisitorStateLookups`
- `ASTHelpersSuggestions`
- `BugPatternNaming` (turned off because we use custom names)