### PR TITLE
rename classes to enforce BugPatternNaming

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,8 +74,7 @@ tasks {
         // enforce errorprone-specific checks
         options.errorprone.check("MemoizeConstantVisitorStateLookups", CheckSeverity.ERROR)
         options.errorprone.check("ASTHelpersSuggestions", CheckSeverity.ERROR)
-        // our bugpattern classes use custom names
-        options.errorprone.check("BugPatternNaming", CheckSeverity.OFF)
+        options.errorprone.check("BugPatternNaming", CheckSeverity.ERROR)
     }
     withType<Javadoc> {
         dependsOn(createJavadocOptionFile)

--- a/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jDoNotLogMessageOfExceptionExplicitly.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jDoNotLogMessageOfExceptionExplicitly.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 @BugPattern(
-    name = "Slf4jDoNotLogMessageOfExceptionExplicitly",
+    altNames = {"ManuallyProvidedMessage"},
     summary =
         "Do not log message returned from Throwable#getMessage and Throwable#getLocalizedMessage",
     tags = {"SLF4J"},
@@ -24,7 +24,8 @@ import java.util.function.Predicate;
     linkType = LinkType.CUSTOM,
     severity = ERROR)
 @AutoService(BugChecker.class)
-public class ManuallyProvidedMessage extends BugChecker implements MethodInvocationTreeMatcher {
+public class Slf4jDoNotLogMessageOfExceptionExplicitly extends BugChecker
+    implements MethodInvocationTreeMatcher {
 
   private static final long serialVersionUID = 7903613628689308557L;
   private static final Predicate<String> MESSAGE_GETTER = "getMessage"::equals;
@@ -49,11 +50,8 @@ public class ManuallyProvidedMessage extends BugChecker implements MethodInvocat
             .filter(meth -> THROWABLE.test(meth.sym.owner.toString()))
             .findFirst();
     if (problem.isPresent()) {
-      return Description.builder(
-              tree,
-              "Slf4jDoNotLogMessageOfExceptionExplicitly",
-              "https://github.com/KengoTODA/findbugs-slf4j#slf4j_manually_provided_message",
-              ERROR,
+      return buildDescription(tree)
+          .setMessage(
               "Do not log message returned from Throwable#getMessage and Throwable#getLocalizedMessage. It is enough to provide throwable instance as the last argument, then binding will log its message.")
           .build();
     }

--- a/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jFormatShouldBeConst.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jFormatShouldBeConst.java
@@ -15,14 +15,14 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 
 @BugPattern(
-    name = "Slf4jFormatShouldBeConst",
+    altNames = {"FormatShouldBeConst"},
     summary = "Format of SLF4J logging should be constant value",
     tags = {"SLF4J"},
     link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_format_should_be_const",
     linkType = LinkType.CUSTOM,
     severity = ERROR)
 @AutoService(BugChecker.class)
-public class FormatShouldBeConst extends BugChecker implements MethodInvocationTreeMatcher {
+public class Slf4jFormatShouldBeConst extends BugChecker implements MethodInvocationTreeMatcher {
   private static final long serialVersionUID = 3271269614137732880L;
 
   @Override
@@ -43,12 +43,6 @@ public class FormatShouldBeConst extends BugChecker implements MethodInvocationT
         String.format(
             "SLF4J logging format should be constant value, but it is \'%s\'",
             state.getSourceForNode(expression));
-    return Description.builder(
-            tree,
-            "Slf4jFormatShouldBeConst",
-            "https://github.com/KengoTODA/findbugs-slf4j#slf4j_format_should_be_const",
-            ERROR,
-            message)
-        .build();
+    return buildDescription(tree).setMessage(message).build();
   }
 }

--- a/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jIllegalPassedClass.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jIllegalPassedClass.java
@@ -30,14 +30,14 @@ import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 
 @BugPattern(
-    name = "Slf4jIllegalPassedClass",
+    altNames = {"IllegalPassedClass"},
     summary = "LoggerFactory.getLogger(Class) should get the class that defines variable",
     tags = {"SLF4J"},
     link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_illegal_passed_class",
     linkType = LinkType.CUSTOM,
     severity = WARNING)
 @AutoService(BugChecker.class)
-public class IllegalPassedClass extends BugChecker implements MethodInvocationTreeMatcher {
+public class Slf4jIllegalPassedClass extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final long serialVersionUID = 8309704818374164342L;
 
@@ -60,13 +60,7 @@ public class IllegalPassedClass extends BugChecker implements MethodInvocationTr
             "LoggerFactory.getLogger(Class) should get one of [%s] but it gets %s",
             enclosingClasses.stream().map(ClassSymbol::className).collect(Collectors.joining(",")),
             type.getSimpleName());
-    Description.Builder builder =
-        Description.builder(
-            tree,
-            "Slf4jIllegalPassedClass",
-            "https://github.com/KengoTODA/findbugs-slf4j#slf4j_illegal_passed_class",
-            WARNING,
-            message);
+    Description.Builder builder = buildDescription(tree).setMessage(message);
 
     VariableTree variableTree = state.findEnclosing(VariableTree.class);
     if (variableTree != null && !variableTree.getModifiers().getFlags().contains(Modifier.STATIC)) {

--- a/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jLoggerShouldBeFinal.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jLoggerShouldBeFinal.java
@@ -13,37 +13,27 @@ import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
-import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.VariableTree;
 import javax.lang.model.element.Modifier;
 
 @BugPattern(
-    name = "Slf4jLoggerShouldBePrivate",
-    summary = "Do not publish Logger field, it should be private",
+    altNames = {"PreferFinalSlf4jLogger"},
+    summary = "Logger field should be final",
     tags = {"SLF4J"},
-    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_private",
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_final",
     linkType = LinkType.CUSTOM,
     severity = WARNING)
 @AutoService(BugChecker.class)
-public class DoNotPublishSlf4jLogger extends BugChecker implements VariableTreeMatcher {
-  private static final long serialVersionUID = 3718668951312958622L;
+public class Slf4jLoggerShouldBeFinal extends BugChecker implements VariableTreeMatcher {
+  private static final long serialVersionUID = -5127926153475887075L;
 
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {
-    if (allOf(isField(), SLF4J_LOGGER, not(hasModifier(Modifier.PRIVATE))).matches(tree, state)) {
-      SuggestedFix.Builder builder = SuggestedFix.builder();
-      SuggestedFixes.addModifiers(tree, state, Modifier.PRIVATE).ifPresent(builder::merge);
-      SuggestedFixes.removeModifiers(tree, state, Modifier.PUBLIC, Modifier.PROTECTED)
-          .ifPresent(builder::merge);
-      return Description.builder(
-              tree,
-              "Slf4jLoggerShouldBePrivate",
-              "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_private",
-              WARNING,
-              "Do not publish Logger field, it should be private")
-          .addFix(builder.build())
+    if (allOf(isField(), SLF4J_LOGGER, not(hasModifier(Modifier.FINAL))).matches(tree, state)) {
+      return buildDescription(tree)
+          .addFix(SuggestedFixes.addModifiers(tree, state, Modifier.FINAL))
           .build();
     }
     return Description.NO_MATCH;

--- a/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jLoggerShouldBeNonStatic.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jLoggerShouldBeNonStatic.java
@@ -21,14 +21,14 @@ import java.util.Optional;
 import javax.lang.model.element.Modifier;
 
 @BugPattern(
-    name = "Slf4jLoggerShouldBeNonStatic",
+    altNames = {"DoNotUseStaticSlf4jLogger"},
     summary = "Do not use static Logger field, use non-static one instead",
     tags = {"SLF4J"},
     link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_non_static",
     linkType = LinkType.CUSTOM,
     severity = SUGGESTION)
 @AutoService(BugChecker.class)
-public class DoNotUseStaticSlf4jLogger extends BugChecker implements VariableTreeMatcher {
+public class Slf4jLoggerShouldBeNonStatic extends BugChecker implements VariableTreeMatcher {
   private static final long serialVersionUID = 2656759159827947106L;
 
   @Override
@@ -38,14 +38,7 @@ public class DoNotUseStaticSlf4jLogger extends BugChecker implements VariableTre
       SuggestedFixes.removeModifiers(tree, state, Modifier.STATIC).ifPresent(builder::merge);
       suggestRename(tree, state).ifPresent(builder::merge);
 
-      return Description.builder(
-              tree,
-              "Slf4jLoggerShouldBeNonStatic",
-              "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_non_static",
-              SUGGESTION,
-              "Do not use static Logger field, use non-static one instead")
-          .addFix(builder.build())
-          .build();
+      return buildDescription(tree).addFix(builder.build()).build();
     }
     return Description.NO_MATCH;
   }

--- a/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jLoggerShouldBePrivate.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jLoggerShouldBePrivate.java
@@ -13,33 +13,31 @@ import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.VariableTree;
 import javax.lang.model.element.Modifier;
 
 @BugPattern(
-    name = "Slf4jLoggerShouldBeFinal",
-    summary = "Logger field should be final",
+    altNames = {"DoNotPublishSlf4jLogger"},
+    summary = "Do not publish Logger field, it should be private",
     tags = {"SLF4J"},
-    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_final",
+    link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_private",
     linkType = LinkType.CUSTOM,
     severity = WARNING)
 @AutoService(BugChecker.class)
-public class PreferFinalSlf4jLogger extends BugChecker implements VariableTreeMatcher {
-  private static final long serialVersionUID = -5127926153475887075L;
+public class Slf4jLoggerShouldBePrivate extends BugChecker implements VariableTreeMatcher {
+  private static final long serialVersionUID = 3718668951312958622L;
 
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {
-    if (allOf(isField(), SLF4J_LOGGER, not(hasModifier(Modifier.FINAL))).matches(tree, state)) {
-      return Description.builder(
-              tree,
-              "Slf4jLoggerShouldBeFinal",
-              "https://github.com/KengoTODA/findbugs-slf4j#slf4j_logger_should_be_final",
-              WARNING,
-              "Logger field should be final")
-          .addFix(SuggestedFixes.addModifiers(tree, state, Modifier.FINAL))
-          .build();
+    if (allOf(isField(), SLF4J_LOGGER, not(hasModifier(Modifier.PRIVATE))).matches(tree, state)) {
+      SuggestedFix.Builder builder = SuggestedFix.builder();
+      SuggestedFixes.addModifiers(tree, state, Modifier.PRIVATE).ifPresent(builder::merge);
+      SuggestedFixes.removeModifiers(tree, state, Modifier.PUBLIC, Modifier.PROTECTED)
+          .ifPresent(builder::merge);
+      return buildDescription(tree).addFix(builder.build()).build();
     }
     return Description.NO_MATCH;
   }

--- a/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jPlaceholderMismatch.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jPlaceholderMismatch.java
@@ -18,14 +18,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @BugPattern(
-    name = "Slf4jPlaceholderMismatch",
+    altNames = {"PlaceholderMismatch"},
     summary = "Count of placeholder does not match with count of parameter",
     tags = {"SLF4J"},
     link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_place_holder_mismatch",
     linkType = LinkType.CUSTOM,
     severity = ERROR)
 @AutoService(BugChecker.class)
-public class PlaceholderMismatch extends BugChecker implements MethodInvocationTreeMatcher {
+public class Slf4jPlaceholderMismatch extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final long serialVersionUID = 1442638758364703416L;
   private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("(.?)(\\\\\\\\)*\\{\\}");
@@ -62,13 +62,7 @@ public class PlaceholderMismatch extends BugChecker implements MethodInvocationT
           String.format(
               "Count of placeholder (%d) does not match with count of parameter (%d)",
               placeholders, argumentSize);
-      return Description.builder(
-              tree,
-              "Slf4jPlaceholderMismatch",
-              "https://github.com/KengoTODA/findbugs-slf4j#slf4j_place_holder_mismatch",
-              ERROR,
-              message)
-          .build();
+      return buildDescription(tree).setMessage(message).build();
     }
     return Description.NO_MATCH;
   }

--- a/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jSignOnlyFormat.java
+++ b/src/main/java/jp/skypencil/errorprone/slf4j/Slf4jSignOnlyFormat.java
@@ -15,14 +15,14 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 
 @BugPattern(
-    name = "Slf4jSignOnlyFormat",
+    altNames = {"SignOnlyFormat"},
     summary = "To make log readable, log format should contain not only sign but also texts",
     tags = {"SLF4J"},
     link = "https://github.com/KengoTODA/findbugs-slf4j#slf4j_sign_only_format",
     linkType = LinkType.CUSTOM,
     severity = ERROR)
 @AutoService(BugChecker.class)
-public class SignOnlyFormat extends BugChecker implements MethodInvocationTreeMatcher {
+public class Slf4jSignOnlyFormat extends BugChecker implements MethodInvocationTreeMatcher {
   private static final long serialVersionUID = 3271269614137732880L;
 
   @Override
@@ -45,13 +45,7 @@ public class SignOnlyFormat extends BugChecker implements MethodInvocationTreeMa
     String message =
         String.format(
             "SLF4J logging format should contain non-sign text, but it is \'%s\'", format);
-    return Description.builder(
-            tree,
-            "Slf4jSignOnlyFormat",
-            "https://github.com/KengoTODA/findbugs-slf4j#slf4j_sign_only_format",
-            ERROR,
-            message)
-        .build();
+    return buildDescription(tree).setMessage(message).build();
   }
 
   private static boolean verifyFormat(String formatString) {

--- a/src/test/java/jp/skypencil/errorprone/slf4j/Slf4JLoggerShouldBeFinalTest.java
+++ b/src/test/java/jp/skypencil/errorprone/slf4j/Slf4JLoggerShouldBeFinalTest.java
@@ -6,10 +6,10 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import java.io.IOException;
 import org.junit.Test;
 
-public class PreferFinalSlf4jLoggerTest {
+public class Slf4JLoggerShouldBeFinalTest {
   @Test
   public void testRefactoringStaticLogger() throws IOException {
-    BugChecker checker = new PreferFinalSlf4jLogger();
+    BugChecker checker = new Slf4jLoggerShouldBeFinal();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
     helper

--- a/src/test/java/jp/skypencil/errorprone/slf4j/Slf4JLoggerShouldBeNonStaticTest.java
+++ b/src/test/java/jp/skypencil/errorprone/slf4j/Slf4JLoggerShouldBeNonStaticTest.java
@@ -6,10 +6,10 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import java.io.IOException;
 import org.junit.Test;
 
-public class DoNotUseStaticSlf4jLoggerTest {
+public class Slf4JLoggerShouldBeNonStaticTest {
   @Test
   public void testRefactoringStaticLogger() throws IOException {
-    BugChecker checker = new DoNotUseStaticSlf4jLogger();
+    BugChecker checker = new Slf4jLoggerShouldBeNonStatic();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
     helper
@@ -35,7 +35,7 @@ public class DoNotUseStaticSlf4jLoggerTest {
 
   @Test
   public void testRefactoringWithAnnotation() throws IOException {
-    BugChecker checker = new DoNotUseStaticSlf4jLogger();
+    BugChecker checker = new Slf4jLoggerShouldBeNonStatic();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
     helper

--- a/src/test/java/jp/skypencil/errorprone/slf4j/Slf4JLoggerShouldBePrivateTest.java
+++ b/src/test/java/jp/skypencil/errorprone/slf4j/Slf4JLoggerShouldBePrivateTest.java
@@ -6,10 +6,10 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import java.io.IOException;
 import org.junit.Test;
 
-public class DoNotPublishSlf4jLoggerTest {
+public class Slf4JLoggerShouldBePrivateTest {
   @Test
   public void testRefactoringPublicLogger() throws IOException {
-    BugChecker checker = new DoNotPublishSlf4jLogger();
+    BugChecker checker = new Slf4jLoggerShouldBePrivate();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
     helper
@@ -35,7 +35,7 @@ public class DoNotPublishSlf4jLoggerTest {
 
   @Test
   public void testRefactoringProtectedLogger() throws IOException {
-    BugChecker checker = new DoNotPublishSlf4jLogger();
+    BugChecker checker = new Slf4jLoggerShouldBePrivate();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
     helper
@@ -61,7 +61,7 @@ public class DoNotPublishSlf4jLoggerTest {
 
   @Test
   public void testRefactoringPackagePrivateLogger() throws IOException {
-    BugChecker checker = new DoNotPublishSlf4jLogger();
+    BugChecker checker = new Slf4jLoggerShouldBePrivate();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
     helper

--- a/src/test/java/jp/skypencil/errorprone/slf4j/Slf4jDoNotLogMessageOfExceptionExplicitlyTest.java
+++ b/src/test/java/jp/skypencil/errorprone/slf4j/Slf4jDoNotLogMessageOfExceptionExplicitlyTest.java
@@ -4,11 +4,12 @@ import com.google.errorprone.CompilationTestHelper;
 import java.io.IOException;
 import org.junit.Test;
 
-public class ManuallyProvidedMessageTest {
+public class Slf4jDoNotLogMessageOfExceptionExplicitlyTest {
   @Test
   public void test() throws IOException {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(ManuallyProvidedMessage.class, getClass());
+        CompilationTestHelper.newInstance(
+            Slf4jDoNotLogMessageOfExceptionExplicitly.class, getClass());
     helper
         .addSourceLines(
             "WithManualMessage.java",

--- a/src/test/java/jp/skypencil/errorprone/slf4j/Slf4jFormatShouldBeConstTest.java
+++ b/src/test/java/jp/skypencil/errorprone/slf4j/Slf4jFormatShouldBeConstTest.java
@@ -4,30 +4,12 @@ import com.google.errorprone.CompilationTestHelper;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SignOnlyFormatTest {
+public class Slf4jFormatShouldBeConstTest {
   private CompilationTestHelper helper;
 
   @Before
   public void setup() {
-    helper = CompilationTestHelper.newInstance(SignOnlyFormat.class, getClass());
-  }
-
-  @Test
-  public void testPlaceholderOnly() {
-    helper
-        .addSourceLines(
-            "PlaceholderOnly.java",
-            "import org.slf4j.Logger;\n"
-                + "import org.slf4j.LoggerFactory;\n"
-                + "\n"
-                + "public class PlaceholderOnly {\n"
-                + "    private final Logger logger = LoggerFactory.getLogger(getClass());\n"
-                + "    void method() {\n"
-                + "        // BUG: Diagnostic contains: SLF4J logging format should contain non-sign text, but it is \'{}, {}\'\n"
-                + "        logger.info(\"{}, {}\", 1, 2);"
-                + "    }\n"
-                + "}")
-        .doTest();
+    helper = CompilationTestHelper.newInstance(Slf4jFormatShouldBeConst.class, getClass());
   }
 
   @Test
@@ -41,6 +23,7 @@ public class SignOnlyFormatTest {
                 + "public class NonConstantFormat {\n"
                 + "    private final Logger logger = LoggerFactory.getLogger(getClass());\n"
                 + "    void method() {\n"
+                + "        // BUG: Diagnostic contains: SLF4J logging format should be constant value, but it is \'this + \" is me\"\'\n"
                 + "        logger.info(this + \" is me\");"
                 + "    }\n"
                 + "}")
@@ -62,8 +45,8 @@ public class SignOnlyFormatTest {
                 + "    private final Marker marker = MarkerFactory.getMarker(\"Sample\");\n"
                 + "    void method() {\n"
                 + "        logger.info(marker, \"I have one placeholder, one parameter and one marker instance. {}\", 1);"
-                + "        // BUG: Diagnostic contains: SLF4J logging format should contain non-sign text, but it is \'{}: {}\'\n"
-                + "        logger.info(marker, \"{}: {}\", 1, 2);"
+                + "        // BUG: Diagnostic contains: SLF4J logging format should be constant value, but it is \'this + \" is me\"\'\n"
+                + "        logger.info(marker, this + \" is me\");"
                 + "    }\n"
                 + "}")
         .doTest();
@@ -78,14 +61,14 @@ public class SignOnlyFormatTest {
                 + "import org.slf4j.LoggerFactory;\n"
                 + "\n"
                 + "public class TernaryInStaticBlock {\n"
-                + "   public static boolean INDENT = true;\n"
-                + "   public static final boolean INDENT_FINAL = true;\n"
+                + "   public static boolean DEBUG = false;\n"
+                + "   public static final boolean DEBUG_FINAL = false;\n"
                 + "   private static final Logger logger = LoggerFactory.getLogger(TernaryInStaticBlock.class);\n"
                 + "\n"
                 + "   static {\n"
-                + "     logger.info((INDENT ? \"  \" : \"\") + \"{}\", 1);\n"
-                + "     // BUG: Diagnostic contains: SLF4J logging format should contain non-sign text, but it is '  {}'\n"
-                + "     logger.info((INDENT_FINAL ? \"  \" : \"\") + \"{}\", 1);\n"
+                + "     // BUG: Diagnostic contains: SLF4J logging format should be constant value, but it is '\"Debug mode \" + (DEBUG ? \"enabled.\" : \"disabled.\")'\n"
+                + "     logger.info(\"Debug mode \" + (DEBUG ? \"enabled.\" : \"disabled.\"));\n"
+                + "     logger.info(\"Debug mode \" + (DEBUG_FINAL ? \"enabled.\" : \"disabled.\"));\n"
                 + "   }\n"
                 + "}\n")
         .doTest();

--- a/src/test/java/jp/skypencil/errorprone/slf4j/Slf4jIllegalPassedClassTest.java
+++ b/src/test/java/jp/skypencil/errorprone/slf4j/Slf4jIllegalPassedClassTest.java
@@ -11,17 +11,17 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import java.io.IOException;
 import org.junit.Test;
 
-public class IllegalPassedClassTest {
+public class Slf4jIllegalPassedClassTest {
   @Test
   public void testSupportedVersion() {
-    assertTrue(IllegalPassedClass.MatherHolder.checkSupportedVersion("3.0.0"));
-    assertTrue(IllegalPassedClass.MatherHolder.checkSupportedVersion("2.11.0"));
-    assertFalse(IllegalPassedClass.MatherHolder.checkSupportedVersion("2.10.0"));
+    assertTrue(Slf4jIllegalPassedClass.MatherHolder.checkSupportedVersion("3.0.0"));
+    assertTrue(Slf4jIllegalPassedClass.MatherHolder.checkSupportedVersion("2.11.0"));
+    assertFalse(Slf4jIllegalPassedClass.MatherHolder.checkSupportedVersion("2.10.0"));
   }
 
   @Test
   public void testRefactoringInstanceField() throws IOException {
-    BugChecker checker = new IllegalPassedClass();
+    BugChecker checker = new Slf4jIllegalPassedClass();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
     helper
@@ -47,7 +47,7 @@ public class IllegalPassedClassTest {
 
   @Test
   public void testRefactoringStaticField() throws IOException {
-    BugChecker checker = new IllegalPassedClass();
+    BugChecker checker = new Slf4jIllegalPassedClass();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass());
     helper
@@ -73,7 +73,7 @@ public class IllegalPassedClassTest {
 
   @Test
   public void test2ndFixForInstanceField() throws IOException {
-    BugChecker checker = new IllegalPassedClass();
+    BugChecker checker = new Slf4jIllegalPassedClass();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass())
             .setFixChooser(FixChoosers.SECOND);
@@ -100,7 +100,7 @@ public class IllegalPassedClassTest {
 
   @Test
   public void testRefactoringInnerClass() throws IOException {
-    BugChecker checker = new IllegalPassedClass();
+    BugChecker checker = new Slf4jIllegalPassedClass();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass())
             .setFixChooser(FixChoosers.SECOND);
@@ -131,7 +131,7 @@ public class IllegalPassedClassTest {
 
   @Test
   public void testRefactoringInnerClass2() throws IOException {
-    BugChecker checker = new IllegalPassedClass();
+    BugChecker checker = new Slf4jIllegalPassedClass();
     BugCheckerRefactoringTestHelper helper =
         BugCheckerRefactoringTestHelper.newInstance(checker, getClass())
             .setFixChooser(FixChoosers.FIRST);
@@ -163,7 +163,7 @@ public class IllegalPassedClassTest {
   @Test
   public void testOtherField() throws IOException {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(IllegalPassedClass.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jIllegalPassedClass.class, getClass());
     helper
         .addSourceLines(
             "WithLoggerFactory.java",
@@ -183,7 +183,7 @@ public class IllegalPassedClassTest {
   @Test
   public void testClassWithoutProblem() throws IOException {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(IllegalPassedClass.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jIllegalPassedClass.class, getClass());
     helper
         .addSourceLines(
             "PrivateLogger.java",
@@ -200,7 +200,7 @@ public class IllegalPassedClassTest {
   @Test
   public void testInnerClassWithoutProblem() throws IOException {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(IllegalPassedClass.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jIllegalPassedClass.class, getClass());
     helper
         .addSourceLines(
             "PrivateLogger.java",
@@ -220,7 +220,7 @@ public class IllegalPassedClassTest {
   @Test
   public void testMethodParameter() throws IOException {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(IllegalPassedClass.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jIllegalPassedClass.class, getClass());
     helper
         .addSourceLines(
             "PrivateLogger.java",

--- a/src/test/java/jp/skypencil/errorprone/slf4j/Slf4jPlaceholderMismatchTest.java
+++ b/src/test/java/jp/skypencil/errorprone/slf4j/Slf4jPlaceholderMismatchTest.java
@@ -7,12 +7,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class PlaceholderMismatchTest {
+public class Slf4jPlaceholderMismatchTest {
   private CompilationTestHelper helper;
 
   @Before
   public void setup() {
-    helper = CompilationTestHelper.newInstance(PlaceholderMismatch.class, getClass());
+    helper = CompilationTestHelper.newInstance(Slf4jPlaceholderMismatch.class, getClass());
   }
 
   @Test
@@ -36,7 +36,7 @@ public class PlaceholderMismatchTest {
   @Test
   public void testMarker() {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(PlaceholderMismatch.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jPlaceholderMismatch.class, getClass());
     helper
         .addSourceLines(
             "WithMarker.java",
@@ -59,7 +59,7 @@ public class PlaceholderMismatchTest {
   @Test
   public void testThrowable() {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(PlaceholderMismatch.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jPlaceholderMismatch.class, getClass());
     helper
         .addSourceLines(
             "WithThrowable.java",
@@ -79,7 +79,7 @@ public class PlaceholderMismatchTest {
   @Test
   public void testTooManyPlaceholders() {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(PlaceholderMismatch.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jPlaceholderMismatch.class, getClass());
     helper
         .addSourceLines(
             "TooManyPlaceholders.java",
@@ -99,7 +99,7 @@ public class PlaceholderMismatchTest {
   @Test
   public void testTooManyParams() {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(PlaceholderMismatch.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jPlaceholderMismatch.class, getClass());
     helper
         .addSourceLines(
             "TooManyParams.java",
@@ -119,7 +119,7 @@ public class PlaceholderMismatchTest {
   @Test
   public void testVarArg() {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(PlaceholderMismatch.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jPlaceholderMismatch.class, getClass());
     helper
         .addSourceLines(
             "VarArg.java",
@@ -139,7 +139,7 @@ public class PlaceholderMismatchTest {
   @Test
   public void testVarArgWithException() {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(PlaceholderMismatch.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jPlaceholderMismatch.class, getClass());
     helper
         .addSourceLines(
             "VarArg.java",
@@ -159,7 +159,7 @@ public class PlaceholderMismatchTest {
   @Test
   public void testNoParams() {
     CompilationTestHelper helper =
-        CompilationTestHelper.newInstance(PlaceholderMismatch.class, getClass());
+        CompilationTestHelper.newInstance(Slf4jPlaceholderMismatch.class, getClass());
     helper
         .addSourceLines(
             "NoParam.java",


### PR DESCRIPTION
- keep old class names als altNames for backwards compatibility
- prefer buildDescription to keep things DRY